### PR TITLE
Supports Sandy Bridge generation CPUs on the Windows version

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Configure
         working-directory: ${{github.workspace}}/build #@TODO figure out how variables are accessed from power shell, as they seem to not be read.
         run: |
-          cmake .. -DCMAKE_BUILD_TYPE=Release -DUSE_STATIC_LIBS=ON  -DVCPKG_TARGET_TRIPLET='x64-windows-static' `
+          cmake .. -DBUILD_ARCH=corei7-avx -DCMAKE_BUILD_TYPE=Release -DUSE_STATIC_LIBS=ON  -DVCPKG_TARGET_TRIPLET='x64-windows-static' `
                 -DCMAKE_TOOLCHAIN_FILE="C:/vcpkg/scripts/buildsystems/vcpkg.cmake"  `
                 -DCMAKE_CXX_COMPILER_LAUNCHER=${{github.workspace}}\ccache.exe `
                 -DCMAKE_C_COMPILER_LAUNCHER=${{github.workspace}}\ccache.exe

--- a/.gitignore
+++ b/.gitignore
@@ -487,4 +487,4 @@ build*/
 models/
 libs/
 
-test.txt
+/test.*

--- a/memo.md
+++ b/memo.md
@@ -34,13 +34,15 @@ nmake
 👆だと結局PCRE2が無理なので、vckg通す
 ```bat
 mkdir build-win
-cmake -DCMAKE_BUILD_TYPE=Release -DUSE_STATIC_LIBS=ON -DVCPKG_TARGET_TRIPLET="x64-windows-static" ..
+cd build-win
+cmake -DBUILD_ARCH=corei7-avx -DCMAKE_BUILD_TYPE=Release -DUSE_STATIC_LIBS=ON -DVCPKG_TARGET_TRIPLET="x64-windows-static" ..
 cmake --build . --config Release --target bergamot_translator_dynamic
 cmake --install . --prefix "../libs" --component bergamot_translator_dynamic
 ```
 
 ```bat
 mkdir build-win-arm
+cd build-win-arm
 cmake -DCMAKE_BUILD_TYPE=Release -DUSE_STATIC_LIBS=ON -DVCPKG_TARGET_TRIPLET="arm64-windows-static" ..
 cmake --build . --config Release --target bergamot_translator_dynamic
 cmake --install . --prefix "../libs" --component bergamot_translator_dynamic

--- a/native-sample/bergamot.cpp
+++ b/native-sample/bergamot.cpp
@@ -14,8 +14,12 @@ int main(int argc, char *argv[]) {
   // モデル設定ファイルのパス
   const char* configPath = argv[1];
 
-  // 翻訳エンジンの初期化
-  void* translator = translator_initialize(configPath);
+  // configPathのアドレスを渡すためのポインタ
+  const char* configPaths[] = { configPath };
+
+  // 必要な引数をtranslator_initializeに渡す
+  // 例: translator_initialize(const char** configPaths, int numPaths)
+  void* translator = translator_initialize(configPaths, 1);
   if (!translator) {
     std::cout << "Failed to initialize translator";
     return 2;


### PR DESCRIPTION
Update CMake build settings to target the `corei7-avx` architecture and document the build process in `memo.md`.